### PR TITLE
Render text in technicolor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,9 @@ export default class TinySDF {
     constructor(options: TinySDFOptions);
     draw(char: string): {
         data: Uint8ClampedArray;
+        dataRed: Uint8ClampedArray;
+        dataGreen: Uint8ClampedArray;
+        dataBlue: Uint8ClampedArray;
         width: number;
         height: number;
         glyphWidth: number;

--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@ a { color: #0af; }
         <label>Font weight</label> <input id="fontweight" type="range" min="100" max="900" step="100" value="400">
     </p>
     <canvas id="canvas" width="1000" height="400"></canvas>
+	<canvas id="canvasRed" width="1000" height="400"></canvas>
+	<canvas id="canvasGreen" width="1000" height="400"></canvas>
+	<canvas id="canvasBlue" width="1000" height="400"></canvas>
     <p id="log"></p>
     <p>
         <label>Size</label> <input type="range" value="128" step="0.01" min="16" max="256.0" id="scale">
@@ -40,12 +43,18 @@ const chars = '🇦🇶ĝक्षि🦽👩🏽‍🦽😍𢄂𡔖城泽材灭
 
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
+const canvasRed = document.getElementById('canvasRed');
+const ctxRed = canvasRed.getContext('2d');
+const canvasGreen = document.getElementById('canvasGreen');
+const ctxGreen = canvasGreen.getContext('2d');
+const canvasBlue = document.getElementById('canvasBlue');
+const ctxBlue = canvasBlue.getContext('2d');
 const segmenter = new Intl.Segmenter();
 
 const sdfs = {};
 
 // Convert alpha-only to RGBA so we can use `putImageData` for building the composite bitmap
-function makeRGBAImageData(alphaChannel, width, height) {
+function makeRGBAImageData(ctx, alphaChannel, width, height) {
     const imageData = ctx.createImageData(width, height);
     for (let i = 0; i < alphaChannel.length; i++) {
         imageData.data[4 * i + 0] = alphaChannel[i];
@@ -58,6 +67,9 @@ function makeRGBAImageData(alphaChannel, width, height) {
 
 function updateSDF() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctxRed.clearRect(0, 0, canvas.width, canvas.height);
+    ctxGreen.clearRect(0, 0, canvas.width, canvas.height);
+    ctxBlue.clearRect(0, 0, canvas.width, canvas.height);
     const fontSize = +document.getElementById('fontsize').value;
     const fontWeight = +document.getElementById('fontweight').value;
     const fontStyle = 'normal';
@@ -72,8 +84,11 @@ function updateSDF() {
     let segment = segments.next();
     for (let y = 0; y + size <= canvas.height && !segment.done; y += size) {
         for (let x = 0; x + size <= canvas.width && !segment.done; x += size) {
-            const {data, width, height} = sdf.draw(segment.value.segment);
-            ctx.putImageData(makeRGBAImageData(data, width, height), x, y);
+            const {data, dataRed, dataGreen, dataBlue, width, height} = sdf.draw(segment.value.segment);
+            ctx.putImageData(makeRGBAImageData(ctx, data, width, height), x, y);
+            ctxRed.putImageData(makeRGBAImageData(ctxRed, dataRed, width, height), x, y);
+            ctxGreen.putImageData(makeRGBAImageData(ctxGreen, dataGreen, width, height), x, y);
+            ctxBlue.putImageData(makeRGBAImageData(ctxBlue, dataBlue, width, height), x, y);
             sdfs[segment.value.segment] = {x, y};
             i++;
             segment = segments.next();
@@ -139,6 +154,9 @@ gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE);
 gl.enable(gl.BLEND);
 
 const texture = gl.createTexture();
+const textureRed = gl.createTexture();
+const textureGreen = gl.createTexture();
+const textureBlue = gl.createTexture();
 
 const vertexBuffer = gl.createBuffer();
 const textureBuffer = gl.createBuffer();
@@ -234,6 +252,42 @@ function drawGL() {
     gl.uniform1f(shader.u_buffer, 0.75);
     gl.uniform1f(shader.u_gamma, gamma * 1.4142 / scale);
     gl.drawArrays(gl.TRIANGLES, 0, vertexBuffer.numItems);
+
+    gl.enable(gl.BLEND);
+    gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, textureRed);
+    gl.uniform1i(shader.u_texture, 0);
+
+    gl.uniform4fv(shader.u_color, [1, 0, 0, 1]);
+    gl.uniform1f(shader.u_buffer, 0.75);
+    gl.uniform1f(shader.u_gamma, gamma * 1.4142 / scale);
+    gl.drawArrays(gl.TRIANGLES, 0, vertexBuffer.numItems);
+
+    gl.enable(gl.BLEND);
+    gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, textureGreen);
+    gl.uniform1i(shader.u_texture, 0);
+
+    gl.uniform4fv(shader.u_color, [0, 1, 0, 1]);
+    gl.uniform1f(shader.u_buffer, 0.75);
+    gl.uniform1f(shader.u_gamma, gamma * 1.4142 / scale);
+    gl.drawArrays(gl.TRIANGLES, 0, vertexBuffer.numItems);
+
+    gl.enable(gl.BLEND);
+    gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, textureBlue);
+    gl.uniform1i(shader.u_texture, 0);
+
+    gl.uniform4fv(shader.u_color, [0, 0, 1, 1]);
+    gl.uniform1f(shader.u_buffer, 0.75);
+    gl.uniform1f(shader.u_gamma, gamma * 1.4142 / scale);
+    gl.drawArrays(gl.TRIANGLES, 0, vertexBuffer.numItems);
 }
 
 document.getElementById('fontsize').oninput = frame;
@@ -255,9 +309,33 @@ function update() {
     updateSDF();
 
     const sdfData = new Uint8Array(ctx.getImageData(0, 0, canvas.width, canvas.height).data);
+    const sdfDataRed = new Uint8Array(ctxRed.getImageData(0, 0, canvas.width, canvas.height).data);
+    const sdfDataGreen = new Uint8Array(ctxGreen.getImageData(0, 0, canvas.width, canvas.height).data);
+    const sdfDataBlue = new Uint8Array(ctxBlue.getImageData(0, 0, canvas.width, canvas.height).data);
 
     gl.bindTexture(gl.TEXTURE_2D, texture);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, canvas.width, canvas.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, sdfData);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    gl.bindTexture(gl.TEXTURE_2D, textureRed);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, canvas.width, canvas.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, sdfDataRed);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    gl.bindTexture(gl.TEXTURE_2D, textureGreen);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, canvas.width, canvas.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, sdfDataGreen);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    gl.bindTexture(gl.TEXTURE_2D, textureBlue);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, canvas.width, canvas.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, sdfDataBlue);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);

--- a/index.html
+++ b/index.html
@@ -36,10 +36,11 @@ a { color: #0af; }
 import {mat4} from 'https://cdn.skypack.dev/pin/gl-matrix@v3.3.0-QDHIgv9E54Kj6suUMV0n/mode=imports,min/optimized/gl-matrix.js';
 import TinySDF from './index.js';
 
-const chars = '𢄂𡔖城泽材灭逐莫笔亡鲜词圣择寻厂睡博勒烟授诺伦岸奥唐卖俄炸载洛健堂旁宫喝借君禁阴园谋宋避抓荣姑孙逃牙束跳顶玉镇雪午练迫爷篇肉嘴馆遍凡础洞卷坦牛宁纸诸训私庄祖丝翻暴森塔默握戏隐熟骨访弱蒙歌店鬼软典欲萨伙遭盘爸扩盖弄雄稳忘亿刺拥徒姆杨齐赛趣曲刀床迎冰虚玩析窗醒妻透购替塞努休虎扬途侵刑绿兄迅套贸毕唯谷轮库迹尤竞街促延震弃甲伟麻川申缓潜闪售灯针哲络抵朱埃抱鼓植纯夏忍页杰筑折郑贝尊吴秀混臣雅振染盛怒舞圆搞狂措姓残秋培迷诚宽宇猛摆梅毁伸摩盟末乃悲拍丁赵硬麦蒋操耶阻订彩抽赞魔纷沿喊违妹浪汇币丰蓝殊献桌啦瓦莱援译夺汽烧距裁偏符勇触课敬哭懂墙袭召罚侠厅拜巧侧韩冒债曼融惯享戴童犹乘挂奖绍厚纵障讯涉彻刊丈爆乌役描洗玛患妙镜唱烦签仙彼弗症仿倾牌陷鸟轰咱菜闭奋庆撤泪茶疾缘播朗杜奶季丹狗尾仪偷奔珠虫驻孔宜艾桥淡翼恨繁寒伴叹旦愈潮粮缩罢聚径恰挑袋灰捕徐珍幕映裂泰隔启尖忠累炎暂估泛荒偿横拒瑞忆孤鼻闹羊呆厉衡胞零穷舍码赫婆魂灾洪腿胆津俗辩胸晓劲贫仁偶辑邦恢赖圈摸仰润堆碰艇稍迟辆废净凶署壁御奉旋冬矿抬蛋晨伏吹鸡倍糊秦盾杯租骑乏隆诊奴摄丧污渡旗甘耐凭扎抢绪粗肩梁幻菲皆碎宙叔岩荡综爬荷悉蒂返井壮薄悄扫敏碍殖详迪矛霍允幅撒剩凯颗骂赏液番箱贴漫酸郎腰舒眉忧浮辛恋餐吓挺励辞艘键伍峰尺昨黎辈贯侦滑券崇扰宪绕趋慈乔阅汗枝拖墨胁插箭腊粉泥氏彭拔骗凤慧媒佩愤扑龄驱惜豪掩兼跃尸肃帕驶堡届欣惠册储飘桑闲惨洁踪勃宾频仇磨递邪撞拟滚奏巡颜剂绩贡疯坡瞧截燃焦殿伪柳锁逼颇昏劝呈搜勤戒驾漂饮曹朵仔柔俩孟腐幼践籍牧凉牲佳娜浓芳稿竹腹跌逻垂遵脉貌柏狱猜怜惑陶兽帐饰贷昌叙躺钢沟寄扶铺邓寿惧询汤盗肥尝匆辉奈扣廷澳嘛董迁凝慰厌脏腾幽怨鞋丢埋泉涌辖躲晋紫艰魏吾慌祝邮吐狠鉴曰械咬邻赤挤弯椅陪割揭韦悟聪雾锋梯猫祥阔誉筹丛牵鸣沈阁穆屈旨袖猎臂蛇贺柱抛鼠瑟戈牢逊迈欺吨琴衰瓶恼燕仲诱狼池疼卢仗冠粒遥吕玄尘冯抚浅敦纠钻晶岂峡苍喷耗凌敲菌赔涂粹扁亏寂煤熊恭湿循暖糖赋抑秩帽哀宿踏烂袁侯抖夹昆肝擦猪炼恒慎搬纽纹玻渔磁铜齿跨押怖漠疲叛遣兹祭醉拳弥斜档稀捷肤疫肿豆削岗晃吞宏癌肚隶履涨耀扭坛拨沃绘伐堪仆郭牺歼墓雇廉契拼惩捉覆刷劫嫌瓜歇雕闷乳串娃缴唤赢莲霸桃妥瘦搭赴岳嘉舱俊址庞耕锐缝悔邀玲惟斥宅添挖呵讼氧浩羽斤酷掠妖祸侍乙妨贪挣汪尿莉悬唇翰仓轨枚盐览傅帅庙芬屏寺胖璃愚滴疏萧姿颤丑劣柯寸扔盯辱匹俱辨饿蜂哦腔郁溃谨糟葛苗肠忌溜鸿爵鹏鹰笼丘桂滋聊挡纲肌茨壳痕碗穴膀卓贤卧膜毅锦欠哩函';
+const chars = '🇦🇶ĝक्षि🦽👩🏽‍🦽😍𢄂𡔖城泽材灭逐莫笔亡鲜词圣择寻厂睡博勒烟授诺伦岸奥唐卖俄炸载洛健堂旁宫喝借君禁阴园谋宋避抓荣姑孙逃牙束跳顶玉镇雪午练迫爷篇肉嘴馆遍凡础洞卷坦牛宁纸诸训私庄祖丝翻暴森塔默握戏隐熟骨访弱蒙歌店鬼软典欲萨伙遭盘爸扩盖弄雄稳忘亿刺拥徒姆杨齐赛趣曲刀床迎冰虚玩析窗醒妻透购替塞努休虎扬途侵刑绿兄迅套贸毕唯谷轮库迹尤竞街促延震弃甲伟麻川申缓潜闪售灯针哲络抵朱埃抱鼓植纯夏忍页杰筑折郑贝尊吴秀混臣雅振染盛怒舞圆搞狂措姓残秋培迷诚宽宇猛摆梅毁伸摩盟末乃悲拍丁赵硬麦蒋操耶阻订彩抽赞魔纷沿喊违妹浪汇币丰蓝殊献桌啦瓦莱援译夺汽烧距裁偏符勇触课敬哭懂墙袭召罚侠厅拜巧侧韩冒债曼融惯享戴童犹乘挂奖绍厚纵障讯涉彻刊丈爆乌役描洗玛患妙镜唱烦签仙彼弗症仿倾牌陷鸟轰咱菜闭奋庆撤泪茶疾缘播朗杜奶季丹狗尾仪偷奔珠虫驻孔宜艾桥淡翼恨繁寒伴叹旦愈潮粮缩罢聚径恰挑袋灰捕徐珍幕映裂泰隔启尖忠累炎暂估泛荒偿横拒瑞忆孤鼻闹羊呆厉衡胞零穷舍码赫婆魂灾洪腿胆津俗辩胸晓劲贫仁偶辑邦恢赖圈摸仰润堆碰艇稍迟辆废净凶署壁御奉旋冬矿抬蛋晨伏吹鸡倍糊秦盾杯租骑乏隆诊奴摄丧污渡旗甘耐凭扎抢绪粗肩梁幻菲皆碎宙叔岩荡综爬荷悉蒂返井壮薄悄扫敏碍殖详迪矛霍允幅撒剩凯颗骂赏液番箱贴漫酸郎腰舒眉忧浮辛恋餐吓挺励辞艘键伍峰尺昨黎辈贯侦滑券崇扰宪绕趋慈乔阅汗枝拖墨胁插箭腊粉泥氏彭拔骗凤慧媒佩愤扑龄驱惜豪掩兼跃尸肃帕驶堡届欣惠册储飘桑闲惨洁踪勃宾频仇磨递邪撞拟滚奏巡颜剂绩贡疯坡瞧截燃焦殿伪柳锁逼颇昏劝呈搜勤戒驾漂饮曹朵仔柔俩孟腐幼践籍牧凉牲佳娜浓芳稿竹腹跌逻垂遵脉貌柏狱猜怜惑陶兽帐饰贷昌叙躺钢沟寄扶铺邓寿惧询汤盗肥尝匆辉奈扣廷澳嘛董迁凝慰厌脏腾幽怨鞋丢埋泉涌辖躲晋紫艰魏吾慌祝邮吐狠鉴曰械咬邻赤挤弯椅陪割揭韦悟聪雾锋梯猫祥阔誉筹丛牵鸣沈阁穆屈旨袖猎臂蛇贺柱抛鼠瑟戈牢逊迈欺吨琴衰瓶恼燕仲诱狼池疼卢仗冠粒遥吕玄尘冯抚浅敦纠钻晶岂峡苍喷耗凌敲菌赔涂粹扁亏寂煤熊恭湿循暖糖赋抑秩帽哀宿踏烂袁侯抖夹昆肝擦猪炼恒慎搬纽纹玻渔磁铜齿跨押怖漠疲叛遣兹祭醉拳弥斜档稀捷肤疫肿豆削岗晃吞宏癌肚隶履涨耀扭坛拨沃绘伐堪仆郭牺歼墓雇廉契拼惩捉覆刷劫嫌瓜歇雕闷乳串娃缴唤赢莲霸桃妥瘦搭赴岳嘉舱俊址庞耕锐缝悔邀玲惟斥宅添挖呵讼氧浩羽斤酷掠妖祸侍乙妨贪挣汪尿莉悬唇翰仓轨枚盐览傅帅庙芬屏寺胖璃愚滴疏萧姿颤丑劣柯寸扔盯辱匹俱辨饿蜂哦腔郁溃谨糟葛苗肠忌溜鸿爵鹏鹰笼丘桂滋聊挡纲肌茨壳痕碗穴膀卓贤卧膜毅锦欠哩函';
 
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
+const segmenter = new Intl.Segmenter();
 
 const sdfs = {};
 
@@ -66,16 +67,16 @@ function updateSDF() {
     const size = fontSize + buffer * 2;
 
     const now = performance.now();
-    const codePoints = chars[Symbol.iterator]();
+    const segments = segmenter.segment(chars)[Symbol.iterator]();
     let i = 0;
-    let codePoint = codePoints.next();
-    for (let y = 0; y + size <= canvas.height && !codePoint.done; y += size) {
-        for (let x = 0; x + size <= canvas.width && !codePoint.done; x += size) {
-            const {data, width, height} = sdf.draw(codePoint.value);
+    let segment = segments.next();
+    for (let y = 0; y + size <= canvas.height && !segment.done; y += size) {
+        for (let x = 0; x + size <= canvas.width && !segment.done; x += size) {
+            const {data, width, height} = sdf.draw(segment.value.segment);
             ctx.putImageData(makeRGBAImageData(data, width, height), x, y);
-            sdfs[codePoint.value] = {x, y};
+            sdfs[segment.value.segment] = {x, y};
             i++;
-            codePoint = codePoints.next();
+            segment = segments.next();
         }
     }
     document.getElementById('log').innerHTML = `${i} characters (${fontSize}px, font-weight: ${fontWeight} with ${buffer}px buffer) rendered in ${Math.round(performance.now() - now)}ms.`;
@@ -142,7 +143,7 @@ const texture = gl.createTexture();
 const vertexBuffer = gl.createBuffer();
 const textureBuffer = gl.createBuffer();
 
-const str = '泽材灭逐莫笔亡鲜词圣择寻厂睡博';
+const str = '泽材灭逐莫笔亡鲜词圣择寻厂睡博🇦🇶👩🏽‍🦽😍';
 
 function drawText(size) {
     const vertexElements = [];
@@ -157,12 +158,12 @@ function drawText(size) {
     const advance = fontsize; // advance
 
     const scale = size / fontsize;
-    const lineWidth = str.length * fontsize * scale;
+    const lineWidth = [...str].length * fontsize * scale;
 
     const pen = {x: canvas2.width / 2 - lineWidth / 2, y: canvas2.height / 2};
-    for (const codePoint of str) {
-        const posX = sdfs[codePoint].x; // pos in sprite x
-        const posY = sdfs[codePoint].y; // pos in sprite y
+    for (const {segment} of segmenter.segment(str)) {
+        const posX = sdfs[segment].x; // pos in sprite x
+        const posY = sdfs[segment].y; // pos in sprite y
 
         vertexElements.push(
             pen.x + ((bx - buf) * scale), pen.y - by * scale,

--- a/test/test.js
+++ b/test/test.js
@@ -50,7 +50,7 @@ test('draws an SDF given a character', () => {
         this.putImageData(nodeCanvas.createImageData(new Uint8ClampedArray(png.data.buffer), png.width), 0, 0);
     };
 
-    const {data, ...metrics} = sdf.draw('材');
+    const {data, dataRed, dataGreen, dataBlue, ...metrics} = sdf.draw('材');
 
     if (process.env.UPDATE) {
         writeFileSync(outMetricsUrl, JSON.stringify(metrics, null, 2));
@@ -80,6 +80,12 @@ test('draws an SDF given a character', () => {
     const numDiffPixels = pixelmatch(expectedImg, actualImg, undefined, width, height, {threshold: 0, includeAA: true});
 
     assert.equal(numDiffPixels, 0, 'SDF pixels');
+
+    const expectedRgb = new Uint8ClampedArray(data.length);
+    expectedRgb.fill(0);
+    assert.deepEqual(expectedRgb, dataRed);
+    assert.deepEqual(expectedRgb, dataGreen);
+    assert.deepEqual(expectedRgb, dataBlue);
 });
 
 test('does not crash on diacritic marks', () => {


### PR DESCRIPTION
This experimental branch brute-forces support for rendering [color fonts](https://css-tricks.com/colrv1-and-css-font-palette-web-typography/) and color emoji by replacing the UTF-16 character iterator with a proper grapheme cluster text segmenter and writing out RGB channel data as separate SDFs.

![A row of Chinese characters followed by the flag of Antarctica, a woman in manual wheelchair emoji, and a face with heart eyes. The three emoji are shown in somewhat posterized, very saturated colors.](https://github.com/user-attachments/assets/a7032378-586b-4433-aa2a-93df50a707bf)

This approach was previously described in [a 2013 blog post](https://gpuhacks.wordpress.com/2013/07/08/signed-distance-field-rendering-of-color-bit-planes/). If all one cares about is emoji, it probably makes more sense to just snapshot the canvas as an ordinary PNG and scale it up or down as needed. Some of the most popular emoji fonts, such as Apple Color Emoji, are based on bitmaps anyways. But color fonts are also pretty cool and aren’t necessarily bitmap-based.